### PR TITLE
KONFLUX-1611: Add labels, (no) licenses & user to Dockerfile

### DIFF
--- a/.tekton/jira-unfurl-bot-saas-main-pull-request.yaml
+++ b/.tekton/jira-unfurl-bot-saas-main-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/jira-unfurl-bot-saas-main-push.yaml
+++ b/.tekton/jira-unfurl-bot-saas-main-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,22 @@
-FROM registry.access.redhat.com/ubi9/python-39:1-172.1712567222 
+FROM registry.access.redhat.com/ubi9/python-39:1-172.1712567222
+
+ARG release=main
+ARG version=latest
+
+LABEL com.redhat.component jira-unfurl-bot
+LABEL description "Slack bot that unfurls Jira issues shared in Slack channels"
+LABEL summary "Slack bot that unfurls Jira issues shared in Slack channels"
+LABEL io.k8s.description "Slack bot that unfurls Jira issues shared in Slack channels"
+LABEL distribution-scope public
+LABEL name jira-unfurl-bot
+LABEL release ${release}
+LABEL version ${version}
+LABEL url https://github.com/openshift-assisted/jira-unfurl-bot
+LABEL vendor "Red Hat, Inc."
+LABEL maintainer "Red Hat"
+
+COPY no_license /licenses/
+
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
* Add labels
* Add default user
* No licenses are declared

Requirements come from https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#additional_resources and would prevent us from releasing an image (we have an exception for "based_on_ubi image")