### PR TITLE
NO-ISSUE: Add renovate config to limit number of PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+    "schedule": ["on Saturday"],
+    "groupName": "Konflux build pipeline",
+    "includePaths": [".tekton/*"],
+    "commitMessagePrefix": "NO-ISSUE: ",
+    "prBodyNotes": [
+        "/lgtm",
+        "/approve"
+    ]
+}
+


### PR DESCRIPTION
Since Konflux added renovates a lot of PR are created

Adding this configuration will

* gather PRs created simultaneously into a single one
* PRs will be created once a week (on Saturday)
* It seems that PR will still requires some manual /lgtm (still require some investigation)